### PR TITLE
Remove the digest from `shfmt-docker`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -12,7 +12,7 @@
   name: shfmt
   description: Shell source code formatter (Docker image)
   language: docker_image
-  entry: --net none mvdan/shfmt:v3.5.1@sha256:ca646edf50d561572593bb63313fdca443c4c4b8472e46114512f7143378a81f
+  entry: --net none mvdan/shfmt:v3.5.1
   args: [-w, -s]
   types: [shell]
   stages: [commit, merge-commit, push, manual]


### PR DESCRIPTION
The specified digest was for the linux/amd64 image which means the hook won't work on linux/arm64 or other architectures.