### PR TITLE
fix(types): exclude csh and tcsh

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
   entry: shfmt
   args: [-w, -s]
   types: [shell]
-  exclude_types: [zsh]
+  exclude_types: [csh, tcsh, zsh]
   stages: [commit, merge-commit, push, manual]
 
 - id: shfmt-docker
@@ -18,5 +18,5 @@
   entry: --net none mvdan/shfmt:v3.6.0@sha256:b68b0e33bf799f393aec27f72da64ec1d84476c8cfa9a2a7bfd0cbbdbfc8d534
   args: [-w, -s]
   types: [shell]
-  exclude_types: [zsh]
+  exclude_types: [csh, tcsh, zsh]
   stages: [commit, merge-commit, push, manual]


### PR DESCRIPTION
C shell is not supported by shfmt as of 3.6.0.

Some types exposed by `identify` remain included that I'm not sure of:
- ash, cbsd, dash: assuming sh compatible
- ksh: assuming mksh compatible

https://github.com/pre-commit/identify/blob/8a04d49546c61c8ba3338fc746e5ee3d8caccd03/identify/extensions.py#L2 https://github.com/pre-commit/identify/blob/8a04d49546c61c8ba3338fc746e5ee3d8caccd03/identify/interpreters.py#L2