### PR TITLE
Added hook variant that enforces google style

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,6 +10,18 @@
   exclude_types: [csh, tcsh, zsh]
   stages: [commit, merge-commit, push, manual]
 
+- id: shfmt-gstyle
+  name: shfmt google-ish style
+  description: Shell source code formatter (native install)
+  language: golang
+  # Note: keep Go version in `go.mod` in sync with shfmt's required Go version
+  additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt@v3.7.0]
+  entry: shfmt
+  args: [-w, -s, -ci, -bn, -i, "2"]
+  types: [shell]
+  exclude_types: [csh, tcsh, zsh]
+  stages: [commit, merge-commit, push, manual]
+
 - id: shfmt-docker
   name: shfmt
   description: Shell source code formatter (Docker image)

--- a/README.md
+++ b/README.md
@@ -11,5 +11,8 @@ Usage in `.pre-commit-config.yaml`:
   hooks:
     # Choose one of:
     - id: shfmt         # native (requires/installs Go to build)
+    - id: shfmt-gstyle  # native, following a style close to that of Google's
     - id: shfmt-docker  # Docker image (requires Docker to run)
 ```
+
+The `gstyle` variant follows configuration described [here](https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#examples).


### PR DESCRIPTION
Added hook variant that enforces style closer to google's, as described here:

https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#examples

Update README.md