### PR TITLE
specify hash algorithm in URL fragment

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,21 +5,21 @@
   entry: |
     wrun
     --url
-    darwin/amd64=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_darwin_amd64#ae1d1ab961c113fb3dc2ff1150f33c3548983550d91da889b3171a5bcfaab14f
+    darwin/amd64=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_darwin_amd64#sha256-ae1d1ab961c113fb3dc2ff1150f33c3548983550d91da889b3171a5bcfaab14f
     --url
-    darwin/arm64=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_darwin_arm64#ad7ff6f666adba3d801eb17365a15539f07296718d39fb62cc2fde6b527178aa
+    darwin/arm64=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_darwin_arm64#sha256-ad7ff6f666adba3d801eb17365a15539f07296718d39fb62cc2fde6b527178aa
     --url
-    linux/386=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_386#9f0b53d765e11c519be1866c5c3e4614f3f4bac4c982c935f879f561c38f17c1
+    linux/386=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_386#sha256-9f0b53d765e11c519be1866c5c3e4614f3f4bac4c982c935f879f561c38f17c1
     --url
-    linux/amd64=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_amd64#0264c424278b18e22453fe523ec01a19805ce3b8ebf18eaf3aadc1edc23f42e3
+    linux/amd64=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_amd64#sha256-0264c424278b18e22453fe523ec01a19805ce3b8ebf18eaf3aadc1edc23f42e3
     --url
-    linux/arm=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_arm#3d1f5a1aede8161293bc42007af5b983f16d62857736c789f062346ed839f299
+    linux/arm=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_arm#sha256-3d1f5a1aede8161293bc42007af5b983f16d62857736c789f062346ed839f299
     --url
-    linux/arm64=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_arm64#111612560d15bd53d8e8f8f85731176ce12f3b418ec473d39a40ed6bbec772de
+    linux/arm64=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_arm64#sha256-111612560d15bd53d8e8f8f85731176ce12f3b418ec473d39a40ed6bbec772de
     --url
-    windows/386=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_windows_386.exe#8bd0422554dd6ce5e07d9d17d020d89254b5c056009005df824e39a8cbdcf6aa
+    windows/386=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_windows_386.exe#sha256-8bd0422554dd6ce5e07d9d17d020d89254b5c056009005df824e39a8cbdcf6aa
     --url
-    windows/amd64=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_windows_amd64.exe#2807b4af91fbbd961b68716de06c044f1b4f897457fc89fba216e5e2e351c64f
+    windows/amd64=https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_windows_amd64.exe#sha256-2807b4af91fbbd961b68716de06c044f1b4f897457fc89fba216e5e2e351c64f
     --
   args: [-w, -s]
   types: [shell]


### PR DESCRIPTION
Hello!

`shfmt` stopped working for me after clearing the cache with the following error:

```
shfmt....................................................................Failed
- hook id: shfmt
- duration: 0.01s
- exit code: 1

wrun: ERROR: prepare hash: invalid fragment format, use hashAlgo-hexDigest
```

Looking at the git repo of `wrun-py`, I saw [this commit](https://github.com/scop/wrun/commit/749e6ae0f492c626ef46b1e4ea6977a64635b99d) where the hashing algorithm now has to be specified. I updated the yaml file accordingly.

@scop Could you please take a look? Thank you!