### PR TITLE
use new stages names to silence pre-commit warning

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,7 +6,7 @@
   args: [-w, -s]
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
-  stages: [commit, merge-commit, push, manual]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
 
 - id: shfmt-src
   name: shfmt
@@ -18,7 +18,7 @@
   args: [-w, -s]
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
-  stages: [commit, merge-commit, push, manual]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
 
 - id: shfmt-docker
   name: shfmt
@@ -29,4 +29,4 @@
   args: [-w, -s]
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
-  stages: [commit, merge-commit, push, manual]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,6 +7,7 @@
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
   stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  minimum_pre_commit_version: 3.2.0 # for "stages" names
 
 - id: shfmt-src
   name: shfmt
@@ -19,6 +20,7 @@
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
   stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  minimum_pre_commit_version: 3.2.0 # for "stages" names
 
 - id: shfmt-docker
   name: shfmt
@@ -30,3 +32,4 @@
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
   stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  minimum_pre_commit_version: 3.2.0 # for "stages" names

--- a/tools/generate_pre_commit_hooks.py
+++ b/tools/generate_pre_commit_hooks.py
@@ -17,6 +17,7 @@ hooks_template = """
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
   stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  minimum_pre_commit_version: 3.2.0 # for "stages" names
 
 - id: shfmt-src
   name: shfmt
@@ -29,6 +30,7 @@ hooks_template = """
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
   stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  minimum_pre_commit_version: 3.2.0 # for "stages" names
 
 - id: shfmt-docker
   name: shfmt
@@ -40,6 +42,7 @@ hooks_template = """
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
   stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  minimum_pre_commit_version: 3.2.0 # for "stages" names
 """
 
 

--- a/tools/generate_pre_commit_hooks.py
+++ b/tools/generate_pre_commit_hooks.py
@@ -16,7 +16,7 @@ hooks_template = """
   args: [-w, -s]
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
-  stages: [commit, merge-commit, push, manual]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
 
 - id: shfmt-src
   name: shfmt
@@ -28,7 +28,7 @@ hooks_template = """
   args: [-w, -s]
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
-  stages: [commit, merge-commit, push, manual]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
 
 - id: shfmt-docker
   name: shfmt
@@ -39,7 +39,7 @@ hooks_template = """
   args: [-w, -s]
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
-  stages: [commit, merge-commit, push, manual]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
 """
 
 


### PR DESCRIPTION
This fixes following warning:

```
[INFO] Initializing environment for https://github.com/scop/pre-commit-shfmt.
[WARNING] repo `https://github.com/scop/pre-commit-shfmt` uses deprecated stage names (commit, merge-commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo https://github.com/scop/pre-commit-shfmt` will fix this.  if it does not -- consider reporting an issue to that repo.
[INFO] Installing environment for https://github.com/scop/pre-commit-shfmt.
```