### PR TITLE
fix: respecting .editorconfig

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   description: Shell source code formatter (prebuilt upstream executable)
   language: python
   entry: shfmt
-  args: [-w, -s]
+  args: [--write]
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
   stages: [pre-commit, pre-merge-commit, pre-push, manual]
@@ -16,7 +16,7 @@
   # Note: keep Go version in `go.mod` in sync with shfmt's required Go version
   additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt@v3.12.0]
   entry: shfmt
-  args: [-w, -s]
+  args: [--write]
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
   stages: [pre-commit, pre-merge-commit, pre-push, manual]
@@ -28,7 +28,7 @@
   language: docker_image
   # Note: use the top level multiplatform image digest here
   entry: --net none mvdan/shfmt:v3.12.0@sha256:307d265ffd25ce832899ae17c93ed5062fc3375c514bba8f52cbf52792735c4d
-  args: [-w, -s]
+  args: [--write]
   types: [shell]
   exclude_types: [csh, tcsh, zsh]
   stages: [pre-commit, pre-merge-commit, pre-push, manual]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Usage in `.pre-commit-config.yaml`:
     - id: shfmt-docker  # Docker image (requires Docker to run)
 ```
 
-> #### Note
+> #### Notes
+>
+> From v3.12.0-2 on, the default args passed to `shfmt`
+> [no longer contain `-s`](https://github.com/mvdan/sh/issues/1173).
 >
 > From v3.7.0-2 on, the `shfmt` id points to the variant that uses a prebuilt
 > upstream executable. The one that builds from source is available as


### PR DESCRIPTION
Passing -s to shfmt 3.12.0 causes .editorconfig not to be loaded.

Refs https://github.com/mvdan/sh/issues/1173

Closes https://github.com/scop/pre-commit-shfmt/issues/39